### PR TITLE
Fix invalid webhook token on message followup

### DIFF
--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -85,7 +85,7 @@ class PlayCommand extends Command {
             // Create a Track from the user's input
             const track = await Track.from(url, message.interaction.user, {
                 async onStart() {
-                    message.interaction.followUp({
+                    message.channel.send({
                         embeds: [
                             new MessageEmbed()
                                 .setAuthor(`▶️ Now playing`)
@@ -129,7 +129,7 @@ class PlayCommand extends Command {
             for (const song of songs) {
                 const track = await Track.from(song.url, message.interaction.user, {
                     async onStart() {
-                        message.interaction.followUp({
+                        message.channel.send({
                             embeds: [
                                 new MessageEmbed()
                                     .setAuthor(`▶️ Now playing`)
@@ -184,7 +184,7 @@ class PlayCommand extends Command {
             try {
                 const track = await Track.from(url, message.interaction.user, {
                     async onStart() {
-                        message.interaction.followUp({
+                        message.channel.send({
                             embeds: [
                                 new MessageEmbed()
                                     .setAuthor(`▶️ Now playing`)


### PR DESCRIPTION
Changes the use of message.interaction.followUp() to message.channel.send to fix the failing music embeds.

Interaction tokens expire after 15 minutes, so long queues would result in the interaction expiring before the bot is able to follow up with a message after onStart() is called.

Fixes #59