### PR TITLE
Remove uses of args.(argName).value

### DIFF
--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -79,8 +79,8 @@ class PlayCommand extends Command {
         // Get URL from args
         let url = ``;
 
-        if (args.song.value.includes("watch?v=") || args.song.value.includes('youtu.be')) {
-            url = args.song.value;
+        if (args.song.includes("watch?v=") || args.song.includes('youtu.be')) {
+            url = args.song;
 
             // Create a Track from the user's input
             const track = await Track.from(url, message.interaction.user, {
@@ -119,9 +119,9 @@ class PlayCommand extends Command {
                         .setTimestamp()
                 ]
             }).catch(global.logger.warn);
-        } else if (args.song.value.includes(`playlist`)) {
+        } else if (args.song.includes(`playlist`)) {
             // Get playlist from YouTube
-            const playlist = await youtube.getPlaylist(args.song.value);
+            const playlist = await youtube.getPlaylist(args.song);
 
             // Get full list of songs from playlist
             const songs = await playlist.getVideos();
@@ -185,7 +185,7 @@ class PlayCommand extends Command {
                 ]
             });
         } else {
-            await youtube.searchVideos(args.song.value, 1)
+            await youtube.searchVideos(args.song, 1)
                 .then(async results => {
                     if (results[0]) {
                         url = results[0].url;

--- a/src/commands/queue.js
+++ b/src/commands/queue.js
@@ -225,13 +225,13 @@ class QueueCommand extends Command {
 
         let reqIndex;
 
-        if (args.position && args.position.value) {
-            reqIndex = args.position.value - 1;
+        if (args.position && args.position) {
+            reqIndex = args.position - 1;
         }
 
-        if (args.position && args.position.value && queue[reqIndex]) {
-            sendDetails(queue[reqIndex], message, args.position.value);
-        } else if (args.position && args.position.value && !queue[reqIndex]) {
+        if (args.position && args.position && queue[reqIndex]) {
+            sendDetails(queue[reqIndex], message, args.position);
+        } else if (args.position && args.position && !queue[reqIndex]) {
             return message.interaction.editReply({
                 embeds: [
                     new MessageEmbed()

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -38,7 +38,7 @@ class RemoveCommand extends Command {
                 ephemeral: true
             });
         } else {
-            const removed = subscription.dequeue(args.position.value - 1);
+            const removed = subscription.dequeue(args.position - 1);
 
             return message.interaction.reply({
                 embeds: [


### PR DESCRIPTION
Apparently .value could be undefined when reading args even though it never used to do that.