### PR TITLE
Add user ID check on oldState

### DIFF
--- a/src/listeners/voiceStateUpdate.js
+++ b/src/listeners/voiceStateUpdate.js
@@ -10,7 +10,7 @@ class VoiceStateUpdateListener extends Listener {
 
     exec(oldState, newState) {
         // console.log(`voiceStateUpdate emitted`);
-        if ((oldState.member.id !== this.client.user.id && oldState.channel && oldState.channel.members.size === 1 && oldState.channel.members.has(this.client.user.id)) || (oldState.channel && !newState.channel)) {
+        if ((oldState.member.id !== this.client.user.id && oldState.channel && oldState.channel.members.size === 1 && oldState.channel.members.has(this.client.user.id)) || (oldState.member.id === this.client.user.id && oldState.channel && !newState.channel)) {
             const subscription = this.client.subscriptions.get(oldState.guild.id);
 
             if (subscription) {


### PR DESCRIPTION
PR #75 introduced a bug that caused the bot to leave whenever a user left the VC, regardless of if the bot was alone or not. The admin kick check correctly looked for the sudden loss of connection, but did not check if the voiceStateUpdate was in the context of the bot user, so it would read every user's update. It now checks the ID of the disconnected member to see if it's the bot that left. 

Fixes #77