### PR TITLE
Fix error when collector looks up current queue

### DIFF
--- a/src/commands/queue.js
+++ b/src/commands/queue.js
@@ -30,6 +30,14 @@ function queueOverflowResolver(arr) {
 async function generateEmbed(page, message, end) {
     const subscription = message.client.subscriptions.get(message.guild.id);
 
+    if (!subscription) {
+        return {
+            embed: new MessageEmbed()
+                .setDescription(`:information_source: The queue is now empty`)
+                .setColor(`#36393f`)
+        };
+    }
+
     const queue = subscription.queue;
 
     const playing = subscription.audioPlayer._state.resource.metadata.video;


### PR DESCRIPTION
After expiring, the collector updates one last time with the current queue
But, if the subscription has since been deleted, it'll error in the console
So, it now checks if the subscription exists
If not, it will simply return "queue is currently empty"